### PR TITLE
refactor(dependencies): use the latest version of eslint-plugin-epsvue

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["eslint-config-epsvue/.stylelintrc.json"]
+  "extends": ["eslint-config-epsvue/stylelint"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "cssnano": "^7.0.6",
         "cypress": "^13.12.0",
         "cz-conventional-changelog": "^3.3.0",
-        "eslint-config-epsvue": "^1.2.1",
+        "eslint-config-epsvue": "^1.2.3",
         "husky": "^9.1.6",
         "jsdom": "^24.1.0",
         "lint-staged": "^15.2.10",
@@ -1307,9 +1307,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -1387,9 +1387,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -4897,9 +4897,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.4.tgz",
-      "integrity": "sha512-HR1gxH5OaiN7XH7uiWH0RLw0RcFySiSoW1ctxmD1ahTw3uGBtkmm/ng0tDU1OtYx5OK6EOL5Y6O21cDflG3Jcg==",
+      "version": "1.23.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
+      "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
       "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -5147,27 +5147,23 @@
       }
     },
     "node_modules/eslint-config-epsvue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-epsvue/-/eslint-config-epsvue-1.2.1.tgz",
-      "integrity": "sha512-adPQANUbaySJ5c/1UlPJWWVQ/5cznyCU6ApNOSjSs27Fb0f+ApoIvAFFHLayf7OXuAlBO0tTQCGuMGdEO4tH/g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-epsvue/-/eslint-config-epsvue-1.2.3.tgz",
+      "integrity": "sha512-f14Vf+5GKveHoy9kQ/hOLD1bXD2cXxTp4vOXhYQJTqAv684KG8KdRWd7VDCcYkW9DelXGXW9/ndX3Jbc9EvkjA==",
       "dev": true,
       "dependencies": {
         "@eslint/js": "^9.14.0",
         "@mapbox/stylelint-processor-arbitrary-tags": "^0.4.0",
         "@vue/eslint-config-prettier": "^10.1.0",
         "@vue/eslint-config-typescript": "^14.1.3",
-        "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-cypress": "^4.1.0",
         "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-storybook": "^0.11.0",
         "eslint-plugin-vue": "^9.30.0",
         "globals": "^15.12.0",
-        "stylelint-config-html": "^1.0.0",
         "stylelint-config-recommended-vue": "^1.5.0",
         "stylelint-config-standard-scss": "^13.0.0",
         "stylelint-config-standard-vue": "^1.0.0",
-        "stylelint-scss": "^6.5.0",
         "typescript-eslint": "^8.14.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cssnano": "^7.0.6",
     "cypress": "^13.12.0",
     "cz-conventional-changelog": "^3.3.0",
-    "eslint-config-epsvue": "^1.2.1",
+    "eslint-config-epsvue": "^1.2.3",
     "husky": "^9.1.6",
     "jsdom": "^24.1.0",
     "lint-staged": "^15.2.10",


### PR DESCRIPTION
Use the lates version to make the usage process more intuitive